### PR TITLE
feat: improve UI input and button components

### DIFF
--- a/src/app/components/ui/Button.jsx
+++ b/src/app/components/ui/Button.jsx
@@ -1,11 +1,65 @@
-// Botón "¡Postularme!"
-export default function Button({ onClick, children }) {
+function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const variantStyles = {
+  primary:
+    "bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600", // default primary style
+  secondary:
+    "bg-white text-blue-600 border border-blue-600 hover:bg-blue-50 focus-visible:ring-blue-600",
+  ghost: "bg-transparent text-blue-600 hover:bg-blue-50 focus-visible:ring-blue-500",
+};
+
+const sizeStyles = {
+  sm: "text-sm px-3 py-1.5",
+  md: "text-base px-4 py-2",
+  lg: "text-lg px-5 py-3",
+};
+
+export default function Button({
+  children,
+  type = "button",
+  onClick,
+  variant = "primary",
+  size = "md",
+  disabled = false,
+  loading = false,
+  fullWidth = false,
+  className,
+  ...props
+}) {
+  const isDisabled = disabled || loading;
+  const variantClass = variantStyles[variant] ?? variantStyles.primary;
+  const sizeClass = sizeStyles[size] ?? sizeStyles.md;
+
   return (
     <button
-        onClick={onClick}
-        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+      type={type}
+      onClick={onClick}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        variantClass,
+        sizeClass,
+        fullWidth && "w-full",
+        isDisabled && "cursor-not-allowed opacity-60",
+        loading && "pointer-events-none",
+        className
+      )}
+      {...props}
     >
-        {children}
+      {loading ? (
+        <span className="flex items-center gap-2">
+          <span
+            className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+            aria-hidden="true"
+          />
+          <span>{children}</span>
+        </span>
+      ) : (
+        children
+      )}
     </button>
-    );
+  );
 }

--- a/src/app/components/ui/Input.jsx
+++ b/src/app/components/ui/Input.jsx
@@ -1,12 +1,75 @@
-// Barra de búsqueda
+import { useId } from "react";
 
-export default function Input({ type = "text", placeholder = "", ...props }) {
+function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const sizeStyles = {
+  sm: "text-sm px-3 py-1.5",
+  md: "text-base px-4 py-2",
+  lg: "text-lg px-4 py-3",
+};
+
+export default function Input({
+  type = "text",
+  placeholder = "",
+  size = "md",
+  disabled = false,
+  error = false,
+  helperText,
+  errorMessage,
+  className,
+  id,
+  ...props
+}) {
+  const reactId = useId();
+  const inputId = id ?? `input-${reactId}`;
+  const isError = Boolean(error);
+  const errorText = isError
+    ? typeof error === "string"
+      ? error
+      : errorMessage
+    : undefined;
+  const sizeClass = sizeStyles[size] ?? sizeStyles.md;
+  const helperContent = !errorText ? helperText : undefined;
+  const messageId = errorText
+    ? `${inputId}-error`
+    : helperContent
+    ? `${inputId}-helper`
+    : undefined;
+
   return (
-    <input
-      type={type}
-      placeholder={placeholder}
-      className="border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      {...props}
-    />
+    <div className="w-full">
+      <input
+        id={inputId}
+        type={type}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-invalid={isError || undefined}
+        aria-describedby={messageId}
+        className={cn(
+          "block w-full rounded-md border transition focus:outline-none focus:ring-2 focus:ring-offset-1",
+          "bg-white text-gray-900 placeholder:text-gray-400",
+          sizeClass,
+          isError
+            ? "border-red-500 focus:border-red-500 focus:ring-red-500"
+            : "border-gray-300 focus:border-blue-500 focus:ring-blue-500",
+          disabled && "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-500",
+          className
+        )}
+        {...props}
+      />
+      {errorText || helperContent ? (
+        <p
+          id={messageId}
+          className={cn(
+            "mt-1 text-sm",
+            errorText ? "text-red-600" : "text-gray-500"
+          )}
+        >
+          {errorText ?? helperContent}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/src/app/components/ui/README.md
+++ b/src/app/components/ui/README.md
@@ -1,0 +1,65 @@
+# Componentes UI: Input y Button
+
+Estos componentes están listos para cubrir los casos de uso más comunes del portal. A continuación se resumen las props clave y ejemplos de uso para facilitar su adopción en nuevas pantallas.
+
+## `<Input />`
+
+Props destacadas:
+
+- `size`: `"sm" | "md" | "lg"` para ajustar el padding y tamaño de fuente.
+- `error`: `boolean` o `string`. Si es `true`, el campo mostrará estilos de error. Si se pasa un texto (`string`) se usará como mensaje de error.
+- `errorMessage`: texto de error explícito. Útil cuando `error` es `true` y el mensaje proviene de otra fuente.
+- `helperText`: texto informativo que aparece debajo del campo cuando no hay error.
+- `disabled`: aplica estilos atenuados y bloquea la interacción.
+- `className`: permite añadir clases adicionales a la entrada.
+
+```jsx
+import Input from "./Input";
+
+function FormEjemplo() {
+  return (
+    <form className="space-y-4">
+      <Input placeholder="Buscar vacantes" />
+      <Input size="sm" helperText="Usa palabras clave" />
+      <Input
+        size="lg"
+        error
+        errorMessage="Este campo es obligatorio"
+        placeholder="Correo electrónico"
+      />
+      <Input disabled placeholder="Solo lectura" />
+    </form>
+  );
+}
+```
+
+> Nota: el componente gestiona `aria-invalid` y `aria-describedby` automáticamente, por lo que los lectores de pantalla reciben el estado y mensaje correcto.
+
+## `<Button />`
+
+Props destacadas:
+
+- `variant`: `"primary" | "secondary" | "ghost"` para controlar el estilo.
+- `size`: `"sm" | "md" | "lg"` para ajustar padding y tipografía.
+- `disabled`: fuerza el botón a estado inactivo.
+- `loading`: muestra un spinner y bloquea la interacción del usuario (`aria-busy`).
+- `fullWidth`: expande el botón al ancho total del contenedor.
+- `className`: clases adicionales para personalizaciones puntuales.
+
+```jsx
+import Button from "./Button";
+
+function AccionesVacante() {
+  return (
+    <div className="space-y-3">
+      <Button onClick={handlePostularse}>¡Postularme!</Button>
+      <Button variant="secondary" size="sm">Guardar búsqueda</Button>
+      <Button variant="ghost" fullWidth>Ver más opciones</Button>
+      <Button loading>Enviando postulación...</Button>
+      <Button disabled>Acción no disponible</Button>
+    </div>
+  );
+}
+```
+
+Estos ejemplos pueden copiarse en Storybook o MDX según se requiera para dejar una referencia visual.


### PR DESCRIPTION
## Summary
- add size, error, helper text, and disabled handling to the Input component with accessible messaging
- extend the Button component with variant, size, loading, and full width options plus visual state updates
- document usage examples for the updated UI components in a README for the UI directory

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6c0ed7340832db50bab4866b233a1